### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # ldap-tgen
 An LDAP (Lightweight Directory Access Protocol) traffic generator. It can be used for ldap server load testing.
+
+
+## License
+
+This project is licensed under the MPL-2.0 license - see the [LICENSE](https://github.com/nokia/ldap-tgen/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.